### PR TITLE
Quick reading patch for 1.01

### DIFF
--- a/pyhmsa/fileformat/datafile.py
+++ b/pyhmsa/fileformat/datafile.py
@@ -133,7 +133,7 @@ class _DataFileReaderMixin:
             handlers.add(handler)
 
         # Parse data
-        elements = root.findall('Data/*')
+        elements = root.findall('Data/*') + root.findall('Dataset')
         count = len(elements)
         for i, element in enumerate(elements):
             key = element.get('Name', 'Inst%i' % len(datafile.data))

--- a/pyhmsa/fileformat/xmlhandler/datum/dataset.py
+++ b/pyhmsa/fileformat/xmlhandler/datum/dataset.py
@@ -1,0 +1,51 @@
+from collections import OrderedDict
+
+from pyhmsa.fileformat.xmlhandler.datum.datum import _DatumXMLHandler
+from pyhmsa.spec.datum.dataset import Dataset
+
+
+class DatasetXMLHandler(_DatumXMLHandler):
+
+    def can_parse(self, element):
+        return element.tag == 'Dataset'
+
+    def _parse_data_offset(self, element):
+        try:
+            return super()._parse_data_offset(element)
+        except ValueError:
+            # DataOffset may be omitted for the first element
+            return 8
+
+    def _parse_int(self, element):
+        return int(element.text)
+
+    def _parse_datum_dimensions(self, element):
+        dimensions = OrderedDict()
+
+        for subelement in element.findall('Dimensions/'):
+            value = self._parse_int(subelement)
+            dimensions[subelement.tag] = value
+
+        return dimensions
+
+    def _parse_numerical_attribute(self, element, attrib=None):
+        if element.tag in {"DataOffset", "DataLength"}:
+            # we know these have to be int from the spec
+            return int(element.text)
+        else:
+            return super()._parse_numerical_attribute(element, attrib)
+
+    def parse(self, element):
+        dtype = self._parse_datum_type(element)
+
+        dimensions = self._parse_datum_dimensions(element)
+        shape = list(dimensions.values())
+
+        buffer = self._parse_binary(element)
+
+        ds = Dataset(shape, dtype, buffer, order="F")
+        ds.dimensions = dimensions
+        return ds
+
+    def can_convert(self, obj):
+        return False

--- a/pyhmsa/fileformat/xmlhandler/xmlhandler.py
+++ b/pyhmsa/fileformat/xmlhandler/xmlhandler.py
@@ -128,18 +128,21 @@ class _XMLHandler(object):
         return obj
 
     def _parse_numerical_attribute(self, element, attrib=None):
-        datatype = element.attrib['DataType']
-        if datatype.startswith('array:'):
-            dtype = DTYPES_LOOKUP_PARSE[datatype[6:]]
-            value = np.array(list(map(float, element.text.split(','))), dtype=dtype)
-            assert len(value) == int(element.attrib['Count'])
+        if "DataType" in element.attrib:
+            datatype = element.attrib['DataType']
+            if datatype.startswith('array:'):
+                dtype = DTYPES_LOOKUP_PARSE[datatype[6:]]
+                value = np.array(list(map(float, element.text.split(','))), dtype=dtype)
+                assert len(value) == int(element.attrib['Count'])
+            else:
+                dtype = DTYPES_LOOKUP_PARSE[datatype]
+                value = dtype.type(float(element.text))
+
+            unit = element.get('Unit')
+
+            return convert_value(value, unit)
         else:
-            dtype = DTYPES_LOOKUP_PARSE[datatype]
-            value = dtype.type(float(element.text))
-
-        unit = element.get('Unit')
-
-        return convert_value(value, unit)
+            return float(element.text)
 
     def _parse_text_attribute(self, element, attrib=None):
         attribs = list(filter(lambda s: s.startswith('alt-lang-'), element.keys()))

--- a/pyhmsa/spec/datum/dataset.py
+++ b/pyhmsa/spec/datum/dataset.py
@@ -1,0 +1,5 @@
+from pyhmsa.spec.datum.datum import _Datum
+
+
+class Dataset(_Datum):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,8 @@ ENTRY_POINTS = \
             'ImageRaster2D = pyhmsa.fileformat.xmlhandler.datum.imageraster:ImageRaster2DXMLHandler',
             'ImageRaster2DSpectral = pyhmsa.fileformat.xmlhandler.datum.imageraster:ImageRaster2DSpectralXMLHandler',
             'ImageRaster2DHyperimage = pyhmsa.fileformat.xmlhandler.datum.imageraster:ImageRaster2DHyperimageXMLHandler',
+
+            'Dataset = pyhmsa.fileformat.xmlhandler.datum.dataset:DatasetXMLHandler',
              ],
          'pyhmsa.fileformat.importer':
             ['EMSA = pyhmsa.fileformat.importer.emsa:ImporterEMSA',


### PR DESCRIPTION
Opening PR that is able to read some 1.01 files, as suggested in #10. 

This could read Pigment EPMA map files from http://www.csiro.au/luminescence/HMSA/examples/index.html, except one or two where it had a problem with a unit of a condition. I wrote to Aaron about that file, because it seemed to me that the unit was not defined in the spec, and he explained that compound units should also work.

I am only posting this as an example of how I hacked it together. I hope it helps.